### PR TITLE
Fix expired jwts when localtime ahead of utc

### DIFF
--- a/generate_token.py
+++ b/generate_token.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import jwt
@@ -81,7 +81,7 @@ def load_private_key():
 
 def generate_jwt_token(username: str, scopes: List[str], private_key, expires_in_hours: int = 1):
     """Generate a JWT token."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     now_timestamp = int(now.timestamp())
     exp_timestamp = int((now + timedelta(hours=expires_in_hours)).timestamp())
     


### PR DESCRIPTION
```
$ date; date -u; ./test_step6.sh
Wed Jul 23 21:35:49 IST 2025
Wed Jul 23 20:35:49 UTC 2025
🧪 Testing Step 6: JWT Token Validation
========================================
🔑 Generating test tokens...
📖 Loading existing private key from mcp_private_key.pem
✅ Private key loaded successfully

🎫 JWT Token Generated:
==============================
👤 Username: alice
🔑 Scopes: mcp:read, mcp:tools
⏰ Expires: 2025-07-23T21:35:49
...
🔍 Testing authenticated MCP initialize (Alice)...
INFO:mcp_http.step6:✅ No Origin header - allowing for MCP client
WARNING:mcp_http.step6:Token has expired
INFO:     127.0.0.1:35758 - "POST /mcp HTTP/1.1" 401 Unauthorized
✅ Authenticated initialize test passed!
📄 Response: {"detail":"Token has expired"}
❌ Initialize response missing authenticated user
🧹 Cleaning up...
INFO:     Shutting down
```